### PR TITLE
Added a note for CMake 3.13+ users

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,8 @@ To build just the dependencies:
 
 ... or you can open the solution file in Visual Studio and build from there instead of invoking cmake --build.
 
+Note, that ```-H``` had been replaced in CMake 3.13 with ```-S```.
+
 If you want to build [LÖVE][love2d], clone LÖVE into the *libs* folder. Megasource will automatically look for it there. E.g.:
 
 	$ git clone https://github.com/love2d/megasource megasource


### PR DESCRIPTION
https://stackoverflow.com/a/54279862
Change ```-H.``` to ```-S.``` for CMake 3.13+, otherwise the following error will pop up:
```Argument "." to --help-command is not a CMake command.  Use --help-command-list to see all commands.```