### PR TITLE
Copy LuaJIT to the same directory as it is used from

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,7 +325,7 @@ if(MSVC)
 	# Copy LuaJIT source to binary dir. LuaJIT builds in-source,
 	# and we don't want to modify the original source tree, so
 	# we copy it.
-	file(COPY libs/${MEGA_LUAJIT_DIR} DESTINATION libs)
+	file(COPY libs/${MEGA_LUAJIT_DIR} DESTINATION ${CMAKE_BINARY_DIR}/libs)
 
 	set(MEGA_LUAJIT_SOURCE_DIR ${CMAKE_BINARY_DIR}/libs/${MEGA_LUAJIT_DIR})
 


### PR DESCRIPTION
[From the CMake docs (emphasis mine):](https://cmake.org/cmake/help/v3.10/command/file.html)
> The COPY signature copies files, directories, and symlinks to a destination folder. Relative input paths are evaluated with respect to the current source directory, and a _relative destination is evaluated with respect to the current build directory_.

When `CMAKE_BINARY_DIR` does not match `CMAKE_CURRENT_BINARY_DIR` (toying around with where CMake is called from) this would cause an issue.