### PR TITLE
Fix .gitignore paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/build/**
-/libs/love/**
+/build
+/libs/love


### PR DESCRIPTION
The previous paths would not work for me:
```
E:\Projects\love\megasource> git check-ignore -v -- libs/love
```
The new paths do work:
```
E:\Projects\love\megasource> git check-ignore -v -- libs/love
.gitignore:2:libs/love  libs/love
```

On `git version 2.43.0.windows.1`